### PR TITLE
fix: resolve updated Lighthouse definition

### DIFF
--- a/src/CollectFieldMiddleware.php
+++ b/src/CollectFieldMiddleware.php
@@ -14,10 +14,8 @@ class CollectFieldMiddleware implements FieldMiddleware
         return "";
     }
 
-    public function handleField(FieldValue $fieldValue, \Closure $next)
+    public function handleField(FieldValue $fieldValue): void
     {
         Collector::addResult($fieldValue);
-
-        return $next($fieldValue);
     }
 }


### PR DESCRIPTION
As we are requiring `dev-master` this has resulted in a breaking change to the method declaration.