### PR TITLE
fix: Require pestphp/pest-2.0 instead of minor version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "php": "^8.2",
         "illuminate/contracts": "^10.0",
         "nuwave/lighthouse": "^6.0.0",
-        "pestphp/pest": "^2.2.3",
+        "pestphp/pest": "^2.0",
         "pestphp/pest-plugin-laravel": "^2.0"
     },
     "require-dev": {


### PR DESCRIPTION
Unfortunately a previous issue had the version locked to 2.2.3 which would not allow us to upgrade pest on the platform.

This takes us back to requiring just the major v2.0