### PR TITLE
feat: add support for Laravel 13

### DIFF
--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -5,18 +5,21 @@ on:
     paths:
       - '**.php'
       - 'phpstan.neon.dist'
+      - '.github/workflows/static.yml'
+  pull_request:
+    branches: [main]
 
 jobs:
   phpstan:
     name: PHPStan
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.3'
+          php-version: '8.4'
           coverage: none
 
       - name: Install composer dependencies
@@ -32,16 +35,16 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.3'
+          php-version: '8.4'
           coverage: none
 
-      - name: Install Dependencies
-        run: composer update --prefer-dist --no-interaction --no-progress --ansi
+      - name: Install composer dependencies
+        uses: ramsey/composer-install@v3
 
       - name: Run ECS
         run: composer test:style

--- a/composer.json
+++ b/composer.json
@@ -9,17 +9,17 @@
     "homepage": "https://github.com/worksome/pest-graphql-coverage",
     "license": "MIT",
     "require": {
-        "php": "^8.2",
-        "illuminate/contracts": "^11.0 || ^12.0",
+        "php": "^8.4",
+        "illuminate/contracts": "^12.0 || ^13.0",
         "nuwave/lighthouse": "^6.44",
-        "pestphp/pest": "^3.0 || ^4.0",
-        "pestphp/pest-plugin-laravel": "^3.0 || ^4.0"
+        "pestphp/pest": "^4.4",
+        "pestphp/pest-plugin-laravel": "^4.1"
     },
     "require-dev": {
-        "larastan/larastan": "^3.1",
-        "nunomaduro/collision": "^7.10 || ^8.1.1",
-        "orchestra/testbench": "^9.12 || ^10.1",
-        "worksome/coding-style": "^3.2"
+        "larastan/larastan": "^3.9",
+        "nunomaduro/collision": "^8.1.1",
+        "orchestra/testbench": "^10.8 || ^11.0",
+        "worksome/coding-style": "^3.4"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
This adds support for Laravel 13, and drops support for older versions.

The following have been dropped:
- Pest 3.x
- Laravel 11